### PR TITLE
Allow for retrieval of the ShopKeep dashboard numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ d.returned_items_report
 
 d.download_inventory
 d.download_transactions(start_date: Time.now - 1.week, end_date: Time.now, detailed: true, tenders: false)
+
+# Get the dashboard numbers
+# (note that values are in cents)
+d.operation_summary(Time.now - 1.month.beginning_of_day, Time.now.end_of_day)
 ```
 
 ## Contributing

--- a/lib/shopkeep_reports/client.rb
+++ b/lib/shopkeep_reports/client.rb
@@ -71,6 +71,14 @@ module ShopkeepReports
       raise ShopkeepException, "#{e.message}"
     end
 
+    def summary_report(report_link, start_date = nil, end_date = nil)
+      new_agent = Mechanize.new
+
+      new_agent.cookie_jar = @@cookie_jar
+
+      JSON.parse(new_agent.get(report_link).body)['data']
+    end
+
     private
     def configuration
       ShopkeepReports.configuration

--- a/lib/shopkeep_reports/configuration.rb
+++ b/lib/shopkeep_reports/configuration.rb
@@ -32,6 +32,10 @@ module ShopkeepReports
       "https://" + @account + ".shopkeepapp.com" + path
     end
 
+    def reporting_uri(path)
+      "https://reporting.api.shopkeepapp.com" + path
+    end
+
     private
     def default_email
       ENV['SHOPKEEP_EMAIL']

--- a/lib/shopkeep_reports/downloader.rb
+++ b/lib/shopkeep_reports/downloader.rb
@@ -75,10 +75,6 @@ module ShopkeepReports
       summary_report('operations_by_hour', start_date, end_date)
     end
 
-    def transaction_total(start_date = nil, end_date = nil)
-      summary_report('transaction_total', start_date, end_date)
-    end
-
     def tenders_summary(start_date = nil, end_date = nil)
       summary_report('tenders_summary', start_date, end_date)
     end

--- a/lib/shopkeep_reports/downloader.rb
+++ b/lib/shopkeep_reports/downloader.rb
@@ -49,6 +49,44 @@ module ShopkeepReports
       Client.instance.download_report_link(configuration.uri("/transactions.csv?#{query.to_query}"))
     end
 
+    def summary_report(type, start_date = nil, end_date = nil)
+      query = {
+        start: start_date.strftime("%B %d %Y %I:%M %p"),
+        finish: end_date.strftime("%B %d %Y %I:%M %p"),
+      }
+
+      Client.instance.authorize
+      Client.instance.summary_report(configuration.uri("/summary_report/#{type}?#{query.to_query}"))
+    end
+
+    def total_net_sales(start_date = nil, end_date = nil)
+      summary_report('total_net_sales', start_date, end_date)
+    end
+
+    def transactions_count(start_date = nil, end_date = nil)
+      summary_report('transactions_count', start_date, end_date)
+    end
+
+    def top_selling_items(start_date = nil, end_date = nil)
+      summary_report('top_selling_items', start_date, end_date)
+    end
+
+    def sales_detail(start_date = nil, end_date = nil)
+      summary_report('sales_detail', start_date, end_date)
+    end
+
+    def tender_breakdown(start_date = nil, end_date = nil)
+      summary_report('tender_breakdown', start_date, end_date)
+    end
+
+    def total_sales_by_hour(start_date = nil, end_date = nil)
+      summary_report('total_sales_by_hour', start_date, end_date)
+    end
+
+    def new_and_returning_customers(start_date = nil, end_date = nil)
+      summary_report('new_and_returning_customers', start_date, end_date)
+    end
+
     private
     def configuration
       ShopkeepReports.configuration

--- a/lib/shopkeep_reports/downloader.rb
+++ b/lib/shopkeep_reports/downloader.rb
@@ -50,6 +50,9 @@ module ShopkeepReports
     end
 
     def summary_report(type, start_date = nil, end_date = nil)
+      start_date = Time.now.beginning_of_day if start_date.nil?
+      end_date = Time.now.end_of_day if end_date.nil?
+
       query = {
         start: start_date.strftime("%Y-%m-%dT%H:%M:%S.%3N"),
         finish: end_date.strftime("%Y-%m-%dT%H:%M:%S.%3N"),

--- a/lib/shopkeep_reports/downloader.rb
+++ b/lib/shopkeep_reports/downloader.rb
@@ -59,16 +59,13 @@ module ShopkeepReports
       Client.instance.summary_report(configuration.reporting_uri("/#{type}"), query)
     end
 
-    def total_net_sales(start_date = nil, end_date = nil)
-      if data = operation_summary(start_date, end_date)
-        data['net_sales'].to_i
-      else
-        0
-      end
-    end
-
     def operation_summary(start_date = nil, end_date = nil)
-      summary_report('operation_summary', start_date, end_date)
+      summary = summary_report('operation_summary', start_date, end_date)
+      mappings = { 'average_items_per_sale' => :to_f }
+      # *most* keys should be integers, but not all. O_o
+      summary.each do |k, v|
+        summary[k] = v.send(mappings[k] || :to_i)
+      end
     end
 
     def operations_by_hour(start_date = nil, end_date = nil)

--- a/lib/shopkeep_reports/downloader.rb
+++ b/lib/shopkeep_reports/downloader.rb
@@ -51,40 +51,40 @@ module ShopkeepReports
 
     def summary_report(type, start_date = nil, end_date = nil)
       query = {
-        start: start_date.strftime("%B %d %Y %I:%M %p"),
-        finish: end_date.strftime("%B %d %Y %I:%M %p"),
+        start: start_date.strftime("%Y-%m-%dT%H:%M:%S.%3N"),
+        finish: end_date.strftime("%Y-%m-%dT%H:%M:%S.%3N"),
       }
 
       Client.instance.authorize
-      Client.instance.summary_report(configuration.uri("/summary_report/#{type}?#{query.to_query}"))
+      Client.instance.summary_report(configuration.reporting_uri("/#{type}"), query)
     end
 
     def total_net_sales(start_date = nil, end_date = nil)
-      summary_report('total_net_sales', start_date, end_date)
+      if data = operation_summary(start_date, end_date)
+        data['net_sales'].to_i
+      else
+        0
+      end
     end
 
-    def transactions_count(start_date = nil, end_date = nil)
-      summary_report('transactions_count', start_date, end_date)
+    def operation_summary(start_date = nil, end_date = nil)
+      summary_report('operation_summary', start_date, end_date)
+    end
+
+    def operations_by_hour(start_date = nil, end_date = nil)
+      summary_report('operations_by_hour', start_date, end_date)
+    end
+
+    def transaction_total(start_date = nil, end_date = nil)
+      summary_report('transaction_total', start_date, end_date)
+    end
+
+    def tenders_summary(start_date = nil, end_date = nil)
+      summary_report('tenders_summary', start_date, end_date)
     end
 
     def top_selling_items(start_date = nil, end_date = nil)
       summary_report('top_selling_items', start_date, end_date)
-    end
-
-    def sales_detail(start_date = nil, end_date = nil)
-      summary_report('sales_detail', start_date, end_date)
-    end
-
-    def tender_breakdown(start_date = nil, end_date = nil)
-      summary_report('tender_breakdown', start_date, end_date)
-    end
-
-    def total_sales_by_hour(start_date = nil, end_date = nil)
-      summary_report('total_sales_by_hour', start_date, end_date)
-    end
-
-    def new_and_returning_customers(start_date = nil, end_date = nil)
-      summary_report('new_and_returning_customers', start_date, end_date)
     end
 
     private


### PR DESCRIPTION
The ShopKeep dashboard displays some interesting statistics, so the downloader now also has:

```
d = ShopkeepReports::Downloader.new
d.operation_summary
d.operations_by_hour
d.tenders_summary
d.top_selling_items
```

These reports are retrieved from a new reporting.api.shopkeepapp.com source which uses some custom authentication and idenfication headers. Unfortunately, ShopKeep only exposes some of these using inline Javascript, so this functionality relies on being able to [capture and parse](https://github.com/pgib/shopkeep_reports/blob/feature/dashboard-reports/lib/shopkeep_reports/client.rb#L117-L119) that data post-login.
